### PR TITLE
Fix Namespace of Type <Version>  in UrlHelper.cs

### DIFF
--- a/redmine-net20-api/Internals/UrlHelper.cs
+++ b/redmine-net20-api/Internals/UrlHelper.cs
@@ -2,7 +2,6 @@
 using System.Collections.Specialized;
 using Redmine.Net.Api.Extensions;
 using Redmine.Net.Api.Types;
-using Version = System.Version;
 
 namespace Redmine.Net.Api.Internals
 {


### PR DESCRIPTION
The Type of Version is Redmine.Net.Api.Types.Version not System.Version in file UrlHelper.cs.