### PR TITLE
Fixed user.Equals() (allow null ApiKey)

### DIFF
--- a/redmine-net20-api/Types/User.cs
+++ b/redmine-net20-api/Types/User.cs
@@ -205,7 +205,7 @@ namespace Redmine.Net.Api.Types
                 && FirstName.Equals(other.FirstName)
                 && LastName.Equals(other.LastName)
                 && Email.Equals(other.Email)
-                && ApiKey.Equals(other.ApiKey)
+				&& (ApiKey != null ? ApiKey.Equals(other.ApiKey) : other.ApiKey == null)
                 && AuthenticationModeId == other.AuthenticationModeId
                 && CreatedOn == other.CreatedOn
                 && LastLoginOn == other.LastLoginOn


### PR DESCRIPTION
Maybe I do something wrong but, after doing something like :
```
var param = new NameValueCollection { { "include", "memberships" } };
var list = await _manager.GetObjectsAsync<User>(param);
```

user.Equals(anotherUser)   throw an Exception because of null ApiKey