### PR TITLE
Fix #265

### DIFF
--- a/src/redmine-net-api/RedmineKeys.cs
+++ b/src/redmine-net-api/RedmineKeys.cs
@@ -131,6 +131,12 @@ namespace Redmine.Net.Api
         /// 
         /// </summary>
         public const string CUSTOM_FIELDS = "custom_fields";
+        
+        /// <summary>
+        /// 
+        /// </summary>
+        public const string DEFAULT_STATUS = "default_status";
+
         /// <summary>
         /// 
         /// </summary>

--- a/src/redmine-net-api/Types/Tracker.cs
+++ b/src/redmine-net-api/Types/Tracker.cs
@@ -30,7 +30,17 @@ namespace Redmine.Net.Api.Types
     [DebuggerDisplay("{" + nameof(DebuggerDisplay) + ",nq}")]
     [XmlRoot(RedmineKeys.TRACKER)]
     public class Tracker : IdentifiableName, IEquatable<Tracker>
-    {
+    {        
+        /// <summary>
+        /// Gets the default (issue) status for this tracker.
+        /// </summary>
+        public IdentifiableName DefaultStatus { get; internal set; }
+
+        /// <summary>
+        /// Gets the description of this tracker.
+        /// </summary>
+        public string Description { get; internal set; }
+
         #region Implementation of IXmlSerialization
         /// <summary>
         /// Generates an object from its XML representation.
@@ -51,6 +61,8 @@ namespace Redmine.Net.Api.Types
                 {
                     case RedmineKeys.ID: Id = reader.ReadElementContentAsInt(); break;
                     case RedmineKeys.NAME: Name = reader.ReadElementContentAsString(); break;
+                    case RedmineKeys.DEFAULT_STATUS: DefaultStatus = new IdentifiableName(reader); break;
+                    case RedmineKeys.DESCRIPTION: Description = reader.ReadElementContentAsString(); break;
                     default: reader.Read(); break;
                 }
             }
@@ -81,6 +93,8 @@ namespace Redmine.Net.Api.Types
                 {
                     case RedmineKeys.ID: Id = reader.ReadAsInt(); break;
                     case RedmineKeys.NAME: Name = reader.ReadAsString(); break;
+                    case RedmineKeys.DEFAULT_STATUS: DefaultStatus = new IdentifiableName(reader); break;
+                    case RedmineKeys.DESCRIPTION: Description = reader.ReadAsString(); break;
                     default: reader.Read(); break;
                 }
             }


### PR DESCRIPTION
 Implemented missing properties to circumvent weird deserialization offsets

This fix seems easier, since I need the default_status value anyway.
bonus content would be a validation of unexpected `BeginObject` tokens.