### PR TITLE
Removed hiding of `Name` property in inherited classes

### DIFF
--- a/src/redmine-net-api/Types/CustomField.cs
+++ b/src/redmine-net-api/Types/CustomField.cs
@@ -37,10 +37,6 @@ namespace Redmine.Net.Api.Types
         /// <summary>
         /// 
         /// </summary>
-        public new string Name { get; set; }
-        /// <summary>
-        /// 
-        /// </summary>
         public string CustomizedType { get; internal set; }
 
         /// <summary>

--- a/src/redmine-net-api/Types/CustomFieldRole.cs
+++ b/src/redmine-net-api/Types/CustomFieldRole.cs
@@ -33,15 +33,9 @@ namespace Redmine.Net.Api.Types
         public CustomFieldRole() { }
 
         internal CustomFieldRole(int id, string name)
+            : base(id, name)
         {
-            Id = id;
-            Name = name;
         }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public new string Name { get; set; }
 
         /// <summary>
         /// 

--- a/src/redmine-net-api/Types/Group.cs
+++ b/src/redmine-net-api/Types/Group.cs
@@ -49,10 +49,6 @@ namespace Redmine.Net.Api.Types
 
         #region Properties
         /// <summary>
-        /// 
-        /// </summary>
-        public new string Name { get; set; }
-        /// <summary>
         /// Represents the group's users.
         /// </summary>
         public IList<GroupUser> Users { get;  set; }

--- a/src/redmine-net-api/Types/GroupUser.cs
+++ b/src/redmine-net-api/Types/GroupUser.cs
@@ -27,11 +27,6 @@ namespace Redmine.Net.Api.Types
     [XmlRoot(RedmineKeys.USER)]
     public sealed class GroupUser : IdentifiableName, IValue
     {
-        /// <summary>
-        /// 
-        /// </summary>
-        public new string Name { get; set; }
-
         #region Implementation of IValue
         /// <summary>
         /// 

--- a/src/redmine-net-api/Types/IdentifiableName.cs
+++ b/src/redmine-net-api/Types/IdentifiableName.cs
@@ -48,6 +48,17 @@ namespace Redmine.Net.Api.Types
         public IdentifiableName() { }
 
         /// <summary>
+        /// Initializes the class by using the given Id and Name.
+        /// </summary>
+        /// <param name="id">The Id.</param>
+        /// <param name="name">The Name.</param>
+        internal IdentifiableName(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="IdentifiableName"/> class.
         /// </summary>
         /// <param name="reader">The reader.</param>
@@ -79,7 +90,7 @@ namespace Redmine.Net.Api.Types
         /// <summary>
         /// Gets or sets the name.
         /// </summary>
-        public string Name { get; internal set; }
+        public virtual string Name { get; set; }
         #endregion
 
         #region Implementation of IXmlSerializable

--- a/src/redmine-net-api/Types/IssueCustomField.cs
+++ b/src/redmine-net-api/Types/IssueCustomField.cs
@@ -35,10 +35,6 @@ namespace Redmine.Net.Api.Types
     {
         #region Properties
         /// <summary>
-        /// 
-        /// </summary>
-        public new string Name { get; set; }
-        /// <summary>
         /// Gets or sets the value.
         /// </summary>
         /// <value>The value.</value>

--- a/src/redmine-net-api/Types/Project.cs
+++ b/src/redmine-net-api/Types/Project.cs
@@ -37,11 +37,6 @@ namespace Redmine.Net.Api.Types
         #region Properties
 
         /// <summary>
-        /// 
-        /// </summary>
-        public new string Name { get; set; }
-
-        /// <summary>
         /// Gets or sets the identifier.
         /// </summary>
         /// <remarks>Required for create</remarks>

--- a/src/redmine-net-api/Types/ProjectEnabledModule.cs
+++ b/src/redmine-net-api/Types/ProjectEnabledModule.cs
@@ -50,11 +50,6 @@ namespace Redmine.Net.Api.Types
 
         #endregion
 
-        /// <summary>
-        /// 
-        /// </summary>
-        public new string Name { get; set; }
-
         #region Implementation of IValue
         /// <summary>
         /// 

--- a/src/redmine-net-api/Types/ProjectIssueCategory.cs
+++ b/src/redmine-net-api/Types/ProjectIssueCategory.cs
@@ -32,15 +32,9 @@ namespace Redmine.Net.Api.Types
         public ProjectIssueCategory() { }
 
         internal ProjectIssueCategory(int id, string name)
+            : base(id, name)
         {
-            Id = id;
-            Name = name;
         }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public new string Name { get; set; }
 
         /// <summary>
         /// 

--- a/src/redmine-net-api/Types/ProjectTimeEntryActivity.cs
+++ b/src/redmine-net-api/Types/ProjectTimeEntryActivity.cs
@@ -16,15 +16,9 @@ namespace Redmine.Net.Api.Types
         public ProjectTimeEntryActivity() { }
 
         internal ProjectTimeEntryActivity(int id, string name)
+            : base(id, name)
         {
-            Id = id;
-            Name = name;
         }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public new string Name { get; set; }
 
         /// <summary>
         /// 

--- a/src/redmine-net-api/Types/ProjectTracker.cs
+++ b/src/redmine-net-api/Types/ProjectTracker.cs
@@ -38,9 +38,8 @@ namespace Redmine.Net.Api.Types
         /// <param name="trackerId">the tracker id: 1 for Bug, etc.</param>
         /// <param name="name"></param>
         public ProjectTracker(int trackerId, string name)
+            : base(trackerId, name)
         {
-            Id = trackerId;
-            Name = name;
         }
 
         /// <summary>
@@ -51,11 +50,6 @@ namespace Redmine.Net.Api.Types
         {
             Id = trackerId;
         }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public new string Name { get; set; }
 
         #region Implementation of IValue
 

--- a/src/redmine-net-api/Types/Role.cs
+++ b/src/redmine-net-api/Types/Role.cs
@@ -34,10 +34,6 @@ namespace Redmine.Net.Api.Types
     {
         #region Properties
         /// <summary>
-        /// 
-        /// </summary>
-        public new string Name { get; set; }
-        /// <summary>
         /// Gets the permissions.
         /// </summary>
         /// <value>

--- a/src/redmine-net-api/Types/TimeEntryActivity.cs
+++ b/src/redmine-net-api/Types/TimeEntryActivity.cs
@@ -38,18 +38,11 @@ namespace Redmine.Net.Api.Types
         public TimeEntryActivity() { }
 
         internal TimeEntryActivity(int id, string name)
+            : base(id, name)
         {
-            Id = id;
-            Name = name;
         }
 
         #region Properties
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public new string Name { get; set; }
-
         /// <summary>
         /// 
         /// </summary>

--- a/src/redmine-net-api/Types/UserGroup.cs
+++ b/src/redmine-net-api/Types/UserGroup.cs
@@ -29,11 +29,6 @@ namespace Redmine.Net.Api.Types
         /// <summary>
         /// 
         /// </summary>
-        public new string Name { get; set; }
-
-        /// <summary>
-        /// 
-        /// </summary>
         /// <returns></returns>
         private string DebuggerDisplay => $"[{nameof(UserGroup)}: {ToString()}]";
 

--- a/src/redmine-net-api/Types/Watcher.cs
+++ b/src/redmine-net-api/Types/Watcher.cs
@@ -28,12 +28,6 @@ namespace Redmine.Net.Api.Types
     [XmlRoot(RedmineKeys.USER)]
     public sealed class Watcher : IdentifiableName, IValue, ICloneable
     {
-        /// <summary>
-        /// 
-        /// </summary>
-        public new string Name { get; set; }
-
-
         #region Implementation of IValue 
         /// <summary>
         /// 


### PR DESCRIPTION
Fixes #292

Made the `Name` property setter public, so it isn't a breaking change. The `Name` must be settable from outside (`Project` for example). So I think this shouldn't matter.