### PR TITLE
 UpdateObject not changing Custom Fields in Version objects #301

### DIFF
--- a/src/redmine-net-api/Types/Version.cs
+++ b/src/redmine-net-api/Types/Version.cs
@@ -145,6 +145,10 @@ namespace Redmine.Net.Api.Types
             writer.WriteElementString(RedmineKeys.SHARING, Sharing.ToString().ToLowerInv());
             writer.WriteDateOrEmpty(RedmineKeys.DUE_DATE, DueDate);
             writer.WriteElementString(RedmineKeys.DESCRIPTION, Description);
+            if (CustomFields != null)
+            {
+               writer.WriteArray(RedmineKeys.CUSTOM_FIELDS, CustomFields);
+            }
         }
         #endregion
 


### PR DESCRIPTION
Not quite sure why one would not want to update custom field values?
The [/versions API](https://www.redmine.org/projects/redmine/wiki/Rest_Versions) for redmine is a bit undocumented, but according to their [integration tests](https://www.redmine.org/projects/redmine/repository/svn/entry/trunk/test/integration/api_test/versions_test.rb?utf8=%E2%9C%93&rev=#L92) should work.