### PR TITLE
use correct framework

### DIFF
--- a/src/redmine-net-api/redmine-net-api.csproj
+++ b/src/redmine-net-api/redmine-net-api.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup Label="Build">
     <RootNamespace>Redmine.Net.Api</RootNamespace>
     <AssemblyName>redmine-net-api</AssemblyName>
-    <TargetFrameworks>net20;net40;net45;net451;net452;net46;net461;net462;net47;net471;net472;net48;net481;net60;net70;net80</TargetFrameworks>
+    <TargetFrameworks>net20;net40;net45;net451;net452;net46;net461;net462;net47;net471;net472;net48;net481;net6.0;net7.0;net8.0</TargetFrameworks>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <Deterministic>True</Deterministic>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks