### PR TITLE
fixed memberships url

### DIFF
--- a/src/redmine-net-api/Net/RedmineApiUrlsExtensions.cs
+++ b/src/redmine-net-api/Net/RedmineApiUrlsExtensions.cs
@@ -48,7 +48,7 @@ internal static class RedmineApiUrlsExtensions
             throw new RedmineException($"Argument '{nameof(projectIdentifier)}' is null or whitespace");
         }
 
-        return $"{RedmineKeys.PROJECT}/{projectIdentifier}/{RedmineKeys.MEMBERSHIPS}.{redmineApiUrls.Format}";
+        return $"{RedmineKeys.PROJECTS}/{projectIdentifier}/{RedmineKeys.MEMBERSHIPS}.{redmineApiUrls.Format}";
     }
 
     public static string ProjectWikiIndex(this RedmineApiUrls redmineApiUrls, string projectId)


### PR DESCRIPTION
at the moment we get NotFound when trying to query project memberships
according to https://www.redmine.org/projects/redmine/wiki/Rest_Memberships the url is /projects/:project_id
so add the missing s

