### PR TITLE
Fixed proliferation of resultList in GetAsync

### DIFF
--- a/src/redmine-net-api/RedmineManagerAsync.cs
+++ b/src/redmine-net-api/RedmineManagerAsync.cs
@@ -141,17 +141,22 @@ public partial class RedmineManager: IRedmineManagerAsync
                     TaskExtensions.WhenAll(pageFetchTasks)
                     #endif
                     .ConfigureAwait(false);
-                
-                foreach (var pageResult in pageResults)
-                {
-                    if (pageResult?.Items == null)
-                    {
-                        continue;
-                    }
-                    
-                    resultList ??= new List<T>();
 
-                    resultList.AddRange(pageResult.Items);
+                if (pageResults.Length == 0)
+                {
+                    return resultList;
+                }
+                else
+                {
+                    resultList = new List<T>();
+                    foreach (var pageResult in pageResults)
+                    {
+                        if (pageResult?.Items == null)
+                        {
+                            continue;
+                        }
+                        resultList.AddRange(pageResult.Items);
+                    }
                 }
             }
         }


### PR DESCRIPTION
I can get the results correctly with the GetInternal method in RedmineManager.cs,
RedmineManagerAsync.cs GetAsync method, the result was doubled.

Line 152, “resultList ? = new List<T>();” is the problem.
Line 152 says new if resultList is not null, but if resultList is not null, the value of pageResult is added in AddRange.

