### PR TITLE
TimeEntry: Change User property to be updateable

### DIFF
--- a/src/redmine-net-api/Types/TimeEntry.cs
+++ b/src/redmine-net-api/Types/TimeEntry.cs
@@ -70,12 +70,12 @@ namespace Redmine.Net.Api.Types
         public IdentifiableName Activity { get; set; }
 
         /// <summary>
-        /// Gets the user.
+        /// Gets or sets the user.
         /// </summary>
         /// <value>
         /// The user.
         /// </value>
-        public IdentifiableName User { get; internal set; }
+        public IdentifiableName User { get; set; }
 
         /// <summary>
         /// Gets or sets the short description for the entry (255 characters max).
@@ -151,6 +151,7 @@ namespace Redmine.Net.Api.Types
         {
             writer.WriteIdIfNotNull(RedmineKeys.ISSUE_ID, Issue);
             writer.WriteIdIfNotNull(RedmineKeys.PROJECT_ID, Project);
+            writer.WriteIdIfNotNull(RedmineKeys.USER_ID, User);
             writer.WriteDateOrEmpty(RedmineKeys.SPENT_ON, SpentOn.GetValueOrDefault(DateTime.Now));
             writer.WriteValueOrEmpty<decimal>(RedmineKeys.HOURS, Hours);
             writer.WriteIdIfNotNull(RedmineKeys.ACTIVITY_ID, Activity);
@@ -210,6 +211,7 @@ namespace Redmine.Net.Api.Types
                 writer.WriteIdIfNotNull(RedmineKeys.ISSUE_ID, Issue);
                 writer.WriteIdIfNotNull(RedmineKeys.PROJECT_ID, Project);
                 writer.WriteIdIfNotNull(RedmineKeys.ACTIVITY_ID, Activity);
+                writer.WriteIdIfNotNull(RedmineKeys.USER_ID, User);
                 writer.WriteDateOrEmpty(RedmineKeys.SPENT_ON, SpentOn.GetValueOrDefault(DateTime.Now));
                 writer.WriteProperty(RedmineKeys.HOURS, Hours);
                 writer.WriteProperty(RedmineKeys.COMMENTS, Comments);


### PR DESCRIPTION
## Type of Change
<!-- Mark with an "x" the types of changes that apply. -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code cleanup / refactor
- [ ] 📖 Documentation update

## Checklist
<!-- Make sure you’ve completed the following before requesting a review. -->
- [X] I have tested my changes locally against a Redmine instance.
- [ ] I have added/updated unit tests if applicable.
- [X] I have updated documentation (README / XML comments / wiki).
- [X] I followed the project’s coding style.
- [ ] New and existing tests pass with my changes.

As per documentation, Redmine allows to set or update the User property of TimeEntry objects. Make the User property setter public and add USER_ID value to Xml and Json serializers.

API documentation link:
https://www.redmine.org/projects/redmine/wiki/Rest_TimeEntries